### PR TITLE
Fix Docker build: install wkhtmltopdf via apt instead of conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-noto-color-emoji \
     fonts-noto \
     fontconfig \
+    wkhtmltopdf \
     && rm -rf /var/lib/apt/lists/*
 
 # Create vicast user

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   # Report generation (Pathway 2 QC)
   - markdown         # Markdown to HTML conversion
   - weasyprint       # HTML to PDF conversion
-  - wkhtmltopdf      # HTML to PNG conversion for publication figures
+  # wkhtmltopdf: installed via apt in Dockerfile (not available in conda channels)
 
   # VICAST-analyze: Variant calling tools (can be omitted for annotation-only)
   - bwa


### PR DESCRIPTION
## Summary
- Docker build fails at `micromamba install` because `wkhtmltopdf` is not available in the bioconda/conda-forge/defaults conda channels
- Moved `wkhtmltopdf` installation from `environment.yml` (conda) to `Dockerfile` (apt-get), where it is available in the Ubuntu jammy repositories
- No functional change — `wkhtmltoimage` remains available in the container for HTML-to-PNG conversion

## Test plan
- [ ] Verify `docker build -t vicast:latest .` completes successfully
- [ ] Verify `wkhtmltoimage --version` works inside the container
- [ ] Verify `convert_html_to_png.sh` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)